### PR TITLE
Add dark mode toggle and dark-theme styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,12 +9,17 @@
     <nav class="navbar">
       <div class="nav-container">
         <a href="index.html" class="nav-logo">8.BIT.BLOG</a>
-        <ul class="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="event.html">Event</a></li>
-        </ul>
+        <div class="nav-actions">
+          <ul class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="event.html">Event</a></li>
+          </ul>
+          <button class="theme-toggle" type="button" aria-pressed="false">
+            Dark mode
+          </button>
+        </div>
       </div>
     </nav>
 
@@ -175,5 +180,6 @@
         <p>&copy; 2024 8.BIT.BLOG. All rights reserved.</p>
       </div>
     </footer>
+    <script src="src/theme-toggle.js"></script>
   </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -9,12 +9,17 @@
     <nav class="navbar">
       <div class="nav-container">
         <a href="index.html" class="nav-logo">8.BIT.BLOG</a>
-        <ul class="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="event.html">Event</a></li>
-        </ul>
+        <div class="nav-actions">
+          <ul class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="event.html">Event</a></li>
+          </ul>
+          <button class="theme-toggle" type="button" aria-pressed="false">
+            Dark mode
+          </button>
+        </div>
       </div>
     </nav>
 
@@ -248,5 +253,6 @@
         <p>&copy; 2024 8.BIT.BLOG. All rights reserved.</p>
       </div>
     </footer>
+    <script src="src/theme-toggle.js"></script>
   </body>
 </html>

--- a/event.html
+++ b/event.html
@@ -9,12 +9,17 @@
     <nav class="navbar">
       <div class="nav-container">
         <a href="index.html" class="nav-logo">8.BIT.BLOG</a>
-        <ul class="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="event.html">Event</a></li>
-        </ul>
+        <div class="nav-actions">
+          <ul class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="event.html">Event</a></li>
+          </ul>
+          <button class="theme-toggle" type="button" aria-pressed="false">
+            Dark mode
+          </button>
+        </div>
       </div>
     </nav>
 
@@ -311,5 +316,6 @@
         <p>&copy; 2024 8.BIT.BLOG. All rights reserved.</p>
       </div>
     </footer>
+    <script src="src/theme-toggle.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,12 +9,17 @@
     <nav class="navbar">
       <div class="nav-container">
         <a href="index.html" class="nav-logo">8.BIT.BLOG</a>
-        <ul class="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="event.html">Event</a></li>
-        </ul>
+        <div class="nav-actions">
+          <ul class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="event.html">Event</a></li>
+          </ul>
+          <button class="theme-toggle" type="button" aria-pressed="false">
+            Dark mode
+          </button>
+        </div>
       </div>
     </nav>
 
@@ -263,5 +268,6 @@
         <p>&copy; 2024 8.BIT.BLOG. All rights reserved.</p>
       </div>
     </footer>
+    <script src="src/theme-toggle.js"></script>
   </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,9 +7,29 @@
   --retro-grey: #333333;
   --retro-light: #f7f7f7;
   --retro-red: #d32f2f;
+  --retro-red-dark: #b71c1c;
   --retro-white: #fff;
+  --retro-contrast: #fff;
+  --retro-border: #e0e0e0;
+  --retro-border-soft: #eee;
+  --retro-muted: #a0a0a0;
   --retro-shadow: rgba(41, 41, 41, 0.3);
   --retro-letter-spacing: 2px;
+}
+
+html.dark {
+  color-scheme: dark;
+  --retro-dark: #f5f5f5;
+  --retro-grey: #d6d6d6;
+  --retro-light: #1d1d1d;
+  --retro-red: #ff5252;
+  --retro-red-dark: #c62828;
+  --retro-white: #0f0f0f;
+  --retro-contrast: #f5f5f5;
+  --retro-border: #2f2f2f;
+  --retro-border-soft: #2a2a2a;
+  --retro-muted: #8b8b8b;
+  --retro-shadow: rgba(0, 0, 0, 0.6);
 }
 
 /* Global styles */
@@ -52,6 +72,12 @@ h6 {
   padding: 1rem 2rem;
 }
 
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
 .nav-logo {
   font-size: 2.2rem;
   color: var(--retro-red);
@@ -81,6 +107,29 @@ h6 {
   color: var(--retro-red);
 }
 
+.theme-toggle {
+  border: 2px solid var(--retro-red);
+  background: var(--retro-white);
+  color: var(--retro-red);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 3px 0 var(--retro-red-dark);
+}
+
+.theme-toggle:hover {
+  background: var(--retro-red);
+  color: var(--retro-contrast);
+}
+
+.theme-toggle:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 var(--retro-red-dark);
+}
+
 /* Main title styling */
 .main-title {
   text-align: center;
@@ -95,7 +144,7 @@ h6 {
 
 .main-title h1 {
   font-size: 3.5rem;
-  color: var(--retro-white);
+  color: var(--retro-contrast);
   text-shadow: 3px 3px 0px var(--retro-red);
   margin-bottom: 1rem;
   font-family: "Jersey 10", cursive;
@@ -144,7 +193,7 @@ h6 {
 
 .sidebar-widget {
   background: var(--retro-light);
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   border-radius: 12px;
   padding: 1.5rem;
 }
@@ -165,7 +214,7 @@ h6 {
 }
 
 .category-list li {
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--retro-border);
   padding: 0.5rem 0;
 }
 
@@ -208,13 +257,13 @@ h6 {
   border-radius: 20px;
   text-decoration: none;
   font-size: 0.8rem;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--retro-border);
   transition: all 0.2s ease;
 }
 
 .tag:hover {
   background: var(--retro-red);
-  color: var(--retro-white);
+  color: var(--retro-contrast);
   border-color: var(--retro-red);
 }
 
@@ -226,7 +275,7 @@ h6 {
 
 .topic-item {
   background: var(--retro-light);
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1rem;
@@ -256,7 +305,7 @@ h6 {
 .contact-form-section {
   margin: 2rem 0;
   background: var(--retro-light);
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   border-radius: 12px;
   padding: 2rem;
 }
@@ -296,7 +345,7 @@ h6 {
 .form-group textarea {
   font-family: 'Inter', sans-serif;
   padding: 0.8rem;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   border-radius: 6px;
   font-size: 0.9rem;
   transition: border-color 0.2s ease;
@@ -337,7 +386,7 @@ h6 {
 
 .contact-submit-button {
   background: var(--retro-red);
-  color: var(--retro-white);
+  color: var(--retro-contrast);
   padding: 1rem 2rem;
   border: none;
   border-radius: 6px;
@@ -347,17 +396,17 @@ h6 {
   cursor: pointer;
   transition: all 0.2s ease;
   align-self: flex-start;
-  box-shadow: 0 4px 0 #b71c1c;
+  box-shadow: 0 4px 0 var(--retro-red-dark);
 }
 
 .contact-submit-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 0 #b71c1c;
+  box-shadow: 0 6px 0 var(--retro-red-dark);
 }
 
 .contact-submit-button:active {
   transform: translateY(2px);
-  box-shadow: 0 2px 0 #b71c1c;
+  box-shadow: 0 2px 0 var(--retro-red-dark);
 }
 
 .contact-link {
@@ -462,7 +511,7 @@ h6 {
   border-radius: 50%;
   border: 3px solid var(--retro-red);
   background: var(--retro-red);
-  color: var(--retro-white);
+  color: var(--retro-contrast);
   font-family: "Inter", sans-serif;
   font-weight: 600;
   cursor: pointer;
@@ -470,12 +519,12 @@ h6 {
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 5px 0 #b71c1c;
+  box-shadow: 0 5px 0 var(--retro-red-dark);
 }
 
 .action-button:active {
   transform: translateY(3px);
-  box-shadow: 0 2px 0 #b71c1c;
+  box-shadow: 0 2px 0 var(--retro-red-dark);
 }
 
 .action-button .arrow {
@@ -493,19 +542,19 @@ h6 {
   background: var(--retro-white);
   color: var(--retro-red);
   border: 3px solid var(--retro-red);
-  box-shadow: 0 5px 0 #b71c1c;
+  box-shadow: 0 5px 0 var(--retro-red-dark);
 }
 
 .author-button:hover {
   background: var(--retro-red);
-  color: var(--retro-white);
+  color: var(--retro-contrast);
 }
 
 /* Gaming Hints Section */
 .hints-section {
   background: var(--retro-light);
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
+  border-top: 1px solid var(--retro-border-soft);
+  border-bottom: 1px solid var(--retro-border-soft);
   margin-top: 4rem;
   padding: 4rem 0;
 }
@@ -542,7 +591,7 @@ h6 {
 
 .hint-card {
   background: var(--retro-white);
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   border-radius: 12px;
   padding: 2rem 1.5rem;
   text-align: center;
@@ -620,7 +669,7 @@ h6 {
   padding: 1.5rem;
   background: var(--retro-light);
   border-radius: 12px;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--retro-border);
   transition: all 0.3s ease;
 }
 
@@ -634,7 +683,7 @@ h6 {
   flex: 0 0 80px;
   text-align: center;
   background: var(--retro-red);
-  color: var(--retro-white);
+  color: var(--retro-contrast);
   border-radius: 8px;
   padding: 1rem 0.5rem;
   display: flex;
@@ -683,7 +732,7 @@ h6 {
 
 /* Footer Styling */
 .footer {
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--retro-border-soft);
   background: var(--retro-light);
   color: var(--retro-dark);
   margin-top: 0;
@@ -746,14 +795,14 @@ h6 {
 }
 
 .footer-bottom {
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--retro-border-soft);
   padding: 1.5rem 2rem;
   text-align: center;
 }
 
 .footer-bottom p {
   font-family: "Inter", sans-serif;
-  color: #a0a0a0;
+  color: var(--retro-muted);
   margin: 0;
   font-size: 0.9rem;
 }
@@ -761,6 +810,12 @@ h6 {
 /* Responsive design */
 @media (max-width: 768px) {
   .nav-container {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-actions {
+    width: 100%;
     flex-direction: column;
     gap: 1rem;
   }

--- a/src/theme-toggle.js
+++ b/src/theme-toggle.js
@@ -1,0 +1,20 @@
+const rootElement = document.documentElement;
+const toggleButton = document.querySelector(".theme-toggle");
+
+const updateToggleState = () => {
+  const isDarkMode = rootElement.classList.contains("dark");
+  if (!toggleButton) {
+    return;
+  }
+  toggleButton.setAttribute("aria-pressed", isDarkMode.toString());
+  toggleButton.textContent = isDarkMode ? "Light mode" : "Dark mode";
+};
+
+if (toggleButton) {
+  toggleButton.addEventListener("click", () => {
+    rootElement.classList.toggle("dark");
+    updateToggleState();
+  });
+}
+
+updateToggleState();

--- a/src/theme-toggle.js
+++ b/src/theme-toggle.js
@@ -1,5 +1,13 @@
 const rootElement = document.documentElement;
 const toggleButton = document.querySelector(".theme-toggle");
+const storageKey = "theme";
+
+const setTheme = (theme) => {
+  const useDark = theme === "dark";
+  rootElement.classList.toggle("dark", useDark);
+  localStorage.setItem(storageKey, useDark ? "dark" : "light");
+  updateToggleState();
+};
 
 const updateToggleState = () => {
   const isDarkMode = rootElement.classList.contains("dark");
@@ -12,9 +20,14 @@ const updateToggleState = () => {
 
 if (toggleButton) {
   toggleButton.addEventListener("click", () => {
-    rootElement.classList.toggle("dark");
-    updateToggleState();
+    const isDarkMode = rootElement.classList.contains("dark");
+    setTheme(isDarkMode ? "light" : "dark");
   });
+}
+
+const storedTheme = localStorage.getItem(storageKey);
+if (storedTheme === "dark" || storedTheme === "light") {
+  rootElement.classList.toggle("dark", storedTheme === "dark");
 }
 
 updateToggleState();


### PR DESCRIPTION
### Motivation
- Provide a site-wide dark mode switch in the top-right of the navigation that toggles a `dark` class on the `html` element to enable dark styling globally.
- Consolidate color tokens into CSS variables and implement dark-mode variants so all components can adapt consistently.

### Description
- Added a theme button to the navigation in `index.html`, `about.html`, `contact.html`, and `event.html` inside a new `.nav-actions` wrapper and included the script at the end of each page via `<script src="src/theme-toggle.js"></script>`.
- Implemented `src/theme-toggle.js` which toggles the `dark` class on `document.documentElement` and keeps the button `aria-pressed` state and label (`Dark mode` / `Light mode`) in sync.
- Expanded `src/styles.css` with additional CSS variables, an `html.dark { ... }` block for dark-mode variable overrides, and component updates (buttons, cards, footer, inputs, etc.) to use the variables so the entire site supports dark mode.
- Added styles for the toggle control (`.theme-toggle`) and adjusted responsive behavior for the nav (`.nav-actions`) to keep the control visible on all screen sizes.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the site pages, which ran successfully.
- Attempted an automated Playwright script to visit `http://127.0.0.1:8000/index.html`, click the theme toggle and capture a screenshot, but the browser run crashed or timed out (Playwright `TargetClosedError` / timed out), so the end-to-end UI check did not complete.
- No other automated tests were provided or run; changes were committed (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2f5aa740833296e0dc692b9125ad)