### PR TITLE
Theme: prefer OS color-scheme by default and switch toggle to icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,8 +16,13 @@
             <li><a href="contact.html">Contact</a></li>
             <li><a href="event.html">Event</a></li>
           </ul>
-          <button class="theme-toggle" type="button" aria-pressed="false">
-            Dark mode
+          <button
+            class="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Enable dark mode"
+          >
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
           </button>
         </div>
       </div>

--- a/contact.html
+++ b/contact.html
@@ -16,8 +16,13 @@
             <li><a href="contact.html">Contact</a></li>
             <li><a href="event.html">Event</a></li>
           </ul>
-          <button class="theme-toggle" type="button" aria-pressed="false">
-            Dark mode
+          <button
+            class="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Enable dark mode"
+          >
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
           </button>
         </div>
       </div>

--- a/event.html
+++ b/event.html
@@ -16,8 +16,13 @@
             <li><a href="contact.html">Contact</a></li>
             <li><a href="event.html">Event</a></li>
           </ul>
-          <button class="theme-toggle" type="button" aria-pressed="false">
-            Dark mode
+          <button
+            class="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Enable dark mode"
+          >
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
           </button>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,13 @@
             <li><a href="contact.html">Contact</a></li>
             <li><a href="event.html">Event</a></li>
           </ul>
-          <button class="theme-toggle" type="button" aria-pressed="false">
-            Dark mode
+          <button
+            class="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Enable dark mode"
+          >
+            <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
           </button>
         </div>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,13 +111,17 @@ h6 {
   border: 2px solid var(--retro-red);
   background: var(--retro-white);
   color: var(--retro-red);
-  padding: 0.4rem 0.9rem;
+  padding: 0.4rem 0.6rem;
   border-radius: 999px;
   font-family: "Inter", sans-serif;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 3px 0 var(--retro-red-dark);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
 }
 
 .theme-toggle:hover {
@@ -128,6 +132,11 @@ h6 {
 .theme-toggle:active {
   transform: translateY(2px);
   box-shadow: 0 1px 0 var(--retro-red-dark);
+}
+
+.theme-toggle__icon {
+  font-size: 1rem;
+  line-height: 1;
 }
 
 /* Main title styling */

--- a/src/theme-toggle.js
+++ b/src/theme-toggle.js
@@ -1,11 +1,14 @@
 const rootElement = document.documentElement;
 const toggleButton = document.querySelector(".theme-toggle");
+const toggleIcon = toggleButton?.querySelector(".theme-toggle__icon");
 const storageKey = "theme";
 
-const setTheme = (theme) => {
+const applyTheme = (theme, { persist = false } = {}) => {
   const useDark = theme === "dark";
   rootElement.classList.toggle("dark", useDark);
-  localStorage.setItem(storageKey, useDark ? "dark" : "light");
+  if (persist) {
+    localStorage.setItem(storageKey, useDark ? "dark" : "light");
+  }
   updateToggleState();
 };
 
@@ -15,19 +18,29 @@ const updateToggleState = () => {
     return;
   }
   toggleButton.setAttribute("aria-pressed", isDarkMode.toString());
-  toggleButton.textContent = isDarkMode ? "Light mode" : "Dark mode";
+  toggleButton.setAttribute(
+    "aria-label",
+    isDarkMode ? "Enable light mode" : "Enable dark mode"
+  );
+  if (toggleIcon) {
+    toggleIcon.textContent = isDarkMode ? "☀️" : "🌙";
+  }
 };
 
 if (toggleButton) {
   toggleButton.addEventListener("click", () => {
     const isDarkMode = rootElement.classList.contains("dark");
-    setTheme(isDarkMode ? "light" : "dark");
+    applyTheme(isDarkMode ? "light" : "dark", { persist: true });
   });
 }
 
 const storedTheme = localStorage.getItem(storageKey);
-if (storedTheme === "dark" || storedTheme === "light") {
-  rootElement.classList.toggle("dark", storedTheme === "dark");
-}
+const hasStoredTheme = storedTheme === "dark" || storedTheme === "light";
+const prefersDark =
+  window.matchMedia &&
+  window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+const initialTheme = hasStoredTheme ? storedTheme : prefersDark ? "dark" : "light";
+applyTheme(initialTheme, { persist: hasStoredTheme });
 
 updateToggleState();


### PR DESCRIPTION
### Motivation
- Make the site respect the user's OS color scheme when no explicit local preference is stored so the initial theme matches system settings.
- Replace the text-based theme toggle with an icon-only control on every page for a more compact UI.
- Improve accessibility by updating `aria-label` and dynamic icon state so assistive tech reflects the current action.

### Description
- Replaced the text toggle with an icon button (`<span class="theme-toggle__icon">`) and `aria-label` in `index.html`, `about.html`, `contact.html`, and `event.html`.
- Updated `src/styles.css` to style the compact icon toggle (`.theme-toggle` and `.theme-toggle__icon`) and adjusted padding/layout for the icon button.
- Rewrote `src/theme-toggle.js` to use `applyTheme(theme, { persist })`, detect a stored theme in `localStorage`, fall back to `prefers-color-scheme` if no stored preference exists, only persist when the user toggles, and update the toggle's `aria-label` and icon glyph (🌙 / ☀️).

### Testing
- Started a static server with `python -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot at `artifacts/theme-toggle.png`, which completed successfully.
- Verified repository state with `git status` and created a commit for the changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e55d4134883329c2648f0688f8d94)